### PR TITLE
[READY] Adding mergemaster check to circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,5 +6,8 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Check for master branch merges
+          command: if [[ -n "$(git log origin/master..HEAD --merges)" ]]; then echo "master was merged into this branch, please use \"git rebase\" instead"; exit 1; fi
+      - run:
           name: Did you fmt
           command: if [[ -n "$(terraform fmt -write=false)" ]]; then echo "Some terraform files need be formatted, run 'terraform fmt' to fix"; exit 1; fi


### PR DESCRIPTION
## Description of PR
Want to be able to validate that no `feature` branch has a `git merge --no-ff master` in it. When bringing a `feature` branch up to date with `master` it should be done with `rebase`

## Previous Behavior
Manually checking commit history if PR was to come in from external sources

## New Behavior
Should catch `git merged --no-ff master` if future PR was to contain such commits

## Tests
See example here: https://circleci.com/gh/sarcasticadmin/terraform-poudriere/36