### PR TITLE
[READY] Make fmt actually show diff during ci test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 jobs:
   build:
@@ -10,4 +11,4 @@ jobs:
           command: if [[ -n "$(git log origin/master..HEAD --merges)" ]]; then echo "master was merged into this branch, please use \"git rebase\" instead"; exit 1; fi
       - run:
           name: Did you fmt
-          command: if [[ -n "$(terraform fmt -write=false)" ]]; then echo "Some terraform files need be formatted, run 'terraform fmt' to fix"; exit 1; fi
+          command: terraform fmt -write=false -check=true -diff=true


### PR DESCRIPTION
## Description of PR
`terraform fmt` can actually show diff instead of having it swallowed by the subshell. Thanks @joshuadcampbell

## Previous Behavior
`terraform fmt` output was displayed, only `echo` about needing to fmt

## New Behavior
`terraform fmt` now displays diff

## Tests
How was this PR tested? During PR made some bad formatting changes to test.
