### PR TITLE
[READY] Issue-11 - Adding trap to bootstrap to scaledown regardless of exit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,15 @@
 ---
 version: 2
 jobs:
-  build:
+  shell-lint:
+    docker:
+      - image: koalaman/shellcheck-alpine:v0.6.0
+    steps:
+      - checkout
+      - run:
+          name: Shell Linting
+          command: for file in $(find . -type f \( -name "*.sh" -o -path "./bootstrap/*" \)); do shellcheck --format=gcc $file; done;
+  terraform-fmt:
     docker:
       - image: hashicorp/terraform:0.11.1
     steps:
@@ -12,3 +20,10 @@ jobs:
       - run:
           name: Did you fmt
           command: terraform fmt -write=false -check=true -diff=true
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - shell-lint
+      - terraform-fmt

--- a/bootstrap/poudriere_userdata.sh
+++ b/bootstrap/poudriere_userdata.sh
@@ -40,7 +40,9 @@ scale_down(){
 
 install_pkgs
 
-trap scale_down EXIT
+if [ $AUTO_SPINDOWN -eq 1 ]; then
+  trap scale_down EXIT
+fi
 
 # Key stuff
 mkdir -p /usr/local/etc/ssl/keys

--- a/bootstrap/poudriere_userdata.sh
+++ b/bootstrap/poudriere_userdata.sh
@@ -52,6 +52,10 @@ chmod 0400 ${SIGNING_KEY}
 # Sync signing key
 aws s3 cp s3://${SIGNING_S3_KEY} ${SIGNING_KEY}
 
+# TODO: Fix stopgap
+mkdir /poudriere
+mkdir /data
+
 # Distfile cache
 mkdir -p /usr/ports/distfiles
 

--- a/bootstrap/poudriere_userdata.sh
+++ b/bootstrap/poudriere_userdata.sh
@@ -9,16 +9,38 @@ export PATH=$PATH:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/
 # like AMI NAME, SIGNING_KEY,
 # S3_BUCKET, SIGNING_S3_KEY
 . /etc/terraform.facts
-ARCH=$(echo ${AMI_NAME} | cut -d '-' -f3)
-VERSION=$(echo ${AMI_NAME} | cut -d ' ' -f2 | cut -d '-' -f1)
-ABI="FreeBSD:$(echo ${VERSION} | cut -d '.' -f1):${ARCH}"
+CURL_FLAGS="-L --connect-timeout 10 --max-time 120"
+ARCH=$(echo "${AMI_NAME}" | cut -d '-' -f3)
+VERSION=$(echo "${AMI_NAME}" | cut -d ' ' -f2 | cut -d '-' -f1)
+ABI="FreeBSD:$(echo "${VERSION}" | cut -d '.' -f1):${ARCH}"
 
-env ASSUME_ALWAYS_YES=YES pkg bootstrap
+install_pkgs(){
+  env ASSUME_ALWAYS_YES=YES pkg bootstrap
 
-# awscli already presenet in ec2 instance
-# but installed after this bootstrap runs
-# so we must install it now
-pkg install -y poudriere awscli curl
+  # awscli already presenet in ec2 instance
+  # but installed after this bootstrap runs
+  # so we must install it now
+  pkg install -y poudriere awscli curl
+}
+
+scale_down(){
+  ## Turn autoscaling off
+  INSTANCE_ID=$(curl $CURL_FLAGS http://169.254.169.254/latest/meta-data/instance-id)
+  REGION=$(curl $CURL_FLAGS http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/\(.*\)[a-z]/\1/')
+  echo "[INFO] Scaling $INSTANCE_ID to 0"
+  AUTOSCALING_GROUP=$(aws ec2 describe-instances \
+              --instance-id ${INSTANCE_ID} \
+              --region ${REGION} \
+              --query 'Reservations[].Instances[].[Tags[?Key==`aws:autoscaling:groupName`].Value]' \
+              --output text)
+  aws autoscaling set-desired-capacity --auto-scaling-group-name ${AUTOSCALING_GROUP} --desired-capacity 0 --region ${REGION}
+  # Consider getting log off the instance
+  # aws s3 cp "/var/log/bootstrap.log" "s3://${S3_BUCKET}/${DATE}/bootstrap-$(date +%s).log"
+}
+
+install_pkgs
+
+trap scale_down EXIT
 
 # Key stuff
 mkdir -p /usr/local/etc/ssl/keys
@@ -40,14 +62,3 @@ poudriere bulk -f /usr/local/etc/poudriere-list -j ${ABI}
 # Url will be hostname/pkgs/ABI
 aws s3 sync "/data/packages/${ABI}-default/.latest/" "s3://${S3_BUCKET}/repos/${ABI}" --delete
 aws s3 sync "/data/logs/bulk/${ABI}-default/latest/" "s3://${S3_BUCKET}/results/${ABI}" --delete
-
-# Turn autoscaling off
-CURL_FLAGS="-L --connect-timeout 10 --max-time 120"
-INSTANCE_ID=$(curl $CURL_FLAGS http://169.254.169.254/latest/meta-data/instance-id)
-REGION=$(curl $CURL_FLAGS http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/\(.*\)[a-z]/\1/')
-AUTOSCALING_GROUP=$(aws ec2 describe-instances \
-            --instance-id ${INSTANCE_ID} \
-            --region ${REGION} \
-            --query 'Reservations[].Instances[].[Tags[?Key==`aws:autoscaling:groupName`].Value]' \
-            --output text)
-aws autoscaling set-desired-capacity --auto-scaling-group-name ${AUTOSCALING_GROUP} --desired-capacity 0 --region ${REGION}

--- a/ec2.tf
+++ b/ec2.tf
@@ -55,6 +55,7 @@ AMI_NAME="${data.aws_ami.freebsd.name}"
 SIGNING_S3_KEY=${var.signing_s3_key}
 SIGNING_KEY=${var.signing_key}
 S3_BUCKET=${var.pkg_s3_bucket}
+AUTO_SPINDOWN="${var.auto_spindown ? 1 : 0}"
 EOF
 
     filename = "terraform.facts"

--- a/variables.tf
+++ b/variables.tf
@@ -66,3 +66,7 @@ variable "poudriere_conf" {
 variable "poudriere_list" {
   default = ""
 }
+
+variable "auto_spindown" {
+  default = true
+}


### PR DESCRIPTION
## Description of PR
* Fixes #11 
* Stopgap for #10 

## Previous Behavior
* Instance would stay online if bootstrap script failed at any part of execution
* Build failed due to directories missing

## New Behavior
* instance will spindown regardless of successful bootstrap script execution
* `auto_spindown` var for controlling the spindown of the poudriere instance
* Added shellcheck to circleci
* Added directories needed by poudriere in version 3.3.2

## Tests
How was this PR tested? ~~TBD~~

* Tested failing spindown of ec2 instance
* Tested successful spindown after poudriere is done building
* Tested poudriere 3.3.2 is now working against this codebase
