### PR TITLE
[READY] Issue-13 - Support more than just FreeBSD RELEASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ module "poudriere" {
 Use the following `awscli` command to look up specific AMIs for
 `FreeBSD 11.1` in region `us-east-1`:
 ```
-aws ec2 describe-images --owners 118940168514 \
+aws ec2 describe-images --owners 782442783595 \
 			--filters "Name=name,Values='FreeBSD 11.1-STABLE-amd64*'" "Name=root-device-type,Values=ebs" \
 			--query 'sort_by(Images, &CreationDate)[].[ImageId, Name]'
 ```
-> NOTE: the account id 118940168514 is the account thats hosting the FreeBSD
+> NOTE: the account id 782442783595 is the account thats hosting the FreeBSD
 > offical images.
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -52,3 +52,32 @@ Check a failed build check compile flags in:
 ```
 less /data/logs/bulk/
 ```
+
+### Unsupport System
+
+If your build fails and you notice the in build logs a similar error:
+
+```
+--End resource limits--
+=======================<phase: check-sanity   >============================
+/!\ ERROR: /!\
+
+Ports Collection support for your FreeBSD version has ended, and no ports are
+guaranteed to build on this system. Please upgrade to a supported release.
+
+No support will be provided if you silence this message by defining
+ALLOW_UNSUPPORTED_SYSTEM.
+
+*** Error code 1
+
+Stop.
+```
+
+This is due to the version of FreeBSD being built is no longer supported, you need to add the following to
+your `make.conf`:
+
+```
+ALLOW_UNSUPPORTED_SYSTEM=yes
+```
+
+Please consider updating the version of the AMI and the jail you are building against

--- a/bootstrap/poudriere_userdata.sh
+++ b/bootstrap/poudriere_userdata.sh
@@ -11,9 +11,8 @@ export PATH=$PATH:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/
 # shellcheck disable=SC1091
 . /etc/terraform.facts
 CURL_FLAGS="-L --connect-timeout 10 --max-time 120"
-ARCH=$(echo "${AMI_NAME}" | cut -d '-' -f3)
-VERSION=$(echo "${AMI_NAME}" | cut -d ' ' -f2 | cut -d '-' -f1)
-ABI="FreeBSD:$(echo "${VERSION}" | cut -d '.' -f1):${ARCH}"
+ARCH=$(uname -p)
+ABI="FreeBSD:$(echo "${JAIL_VERSION}" | cut -d '.' -f1):${ARCH}"
 
 install_pkgs(){
   env ASSUME_ALWAYS_YES=YES pkg bootstrap

--- a/bootstrap/poudriere_userdata.sh
+++ b/bootstrap/poudriere_userdata.sh
@@ -65,7 +65,7 @@ mkdir -p /usr/ports/distfiles
 
 poudriere ports -c
 
-poudriere jail -c -j "${ABI}" -v "${VERSION}-RELEASE" -a "${ARCH}"
+poudriere jail -c -j "${ABI}" -v "${JAIL_VERSION}" -a "${ARCH}"
 
 poudriere bulk -f /usr/local/etc/poudriere-list -j "${ABI}"
 

--- a/ec2.tf
+++ b/ec2.tf
@@ -11,7 +11,7 @@ data "aws_ami" "freebsd" {
     values = ["hvm"]
   }
 
-  owners = ["118940168514"] # Account for FreeBSD hosted AMIs
+  owners = ["782442783595"] # Account for FreeBSD hosted AMIs
 }
 
 resource "aws_security_group" "poudriere" {

--- a/ec2.tf
+++ b/ec2.tf
@@ -55,6 +55,7 @@ AMI_NAME="${data.aws_ami.freebsd.name}"
 SIGNING_S3_KEY=${var.signing_s3_key}
 SIGNING_KEY=${var.signing_key}
 S3_BUCKET=${var.pkg_s3_bucket}
+JAIL_VERSION="${var.jail_version}"
 AUTO_SPINDOWN="${var.auto_spindown ? 1 : 0}"
 EOF
 

--- a/ec2.tf
+++ b/ec2.tf
@@ -104,6 +104,10 @@ resource "aws_launch_configuration" "poudriere" {
   ebs_optimized     = false
   enable_monitoring = false
 
+  root_block_device {
+    volume_size = "${var.volume_size}"
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "poudriere_url" {
-  value = "http://${var.pkg_s3_bucket}/results/FreeBSD:11:amd64/build.html"
+  value = "http://${var.pkg_s3_bucket}/results/FreeBSD:${element(split(".", var.jail_version),0)}:amd64/build.html"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,12 +6,12 @@ variable "aws_region" {
 # If wildcard it will always choose latest
 variable "aws_ami_name_filter" {
   description = "Name filter for matching FreeBSD ami"
-  default     = "FreeBSD 11.1-STABLE-amd64*"
+  default     = "FreeBSD 12.1-STABLE-amd64*"
 }
 
 variable "instance_size" {
   description = "ec2 instance size for building"
-  default     = "t2.large"
+  default     = "t3a.large"
 }
 
 variable "vpc_id" {
@@ -65,6 +65,10 @@ variable "poudriere_conf" {
 
 variable "poudriere_list" {
   default = ""
+}
+
+variable "jail_version" {
+  default = "12.1-RELEASE"
 }
 
 variable "auto_spindown" {

--- a/variables.tf
+++ b/variables.tf
@@ -71,6 +71,10 @@ variable "jail_version" {
   default = "12.1-RELEASE"
 }
 
+variable "volume_size" {
+  default = 10
+}
+
 variable "auto_spindown" {
   default = true
 }


### PR DESCRIPTION
## Description of PR
Fixes: #13 #9 

## Previous Behavior
* Couldnt only build on specific versions of FreeBSD

## New Behavior
* Possible to specify any version of FreeBSD and the jail used to build the ports in

## Tests
* CI
* Personal AWS acct
Successfully built 12.1 pkgs:
![Screen Shot 2020-03-17 at 8 48 36 AM](https://user-images.githubusercontent.com/30531572/76874272-311c2800-682c-11ea-9dbc-21af6ea07de4.png)

Successfully built 11.3 pkgs:
![Screen Shot 2020-03-17 at 8 48 47 AM](https://user-images.githubusercontent.com/30531572/76874275-32e5eb80-682c-11ea-9aae-e72f6426f491.png)

